### PR TITLE
Include fpage and lpage values in article JSON.

### DIFF
--- a/api/data/articles/00001.json
+++ b/api/data/articles/00001.json
@@ -11,6 +11,8 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00001/ijm-00001.pdf",
     "copyright": {

--- a/api/data/articles/00002.json
+++ b/api/data/articles/00002.json
@@ -11,6 +11,8 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
+    "fpage": 3,
+    "lpage": 9,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00002/ijm-00002.pdf",
     "subjects": [

--- a/api/data/articles/00003.json
+++ b/api/data/articles/00003.json
@@ -11,6 +11,8 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
+    "fpage": 10,
+    "lpage": 25,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00003/ijm-00003.pdf",
     "subjects": [

--- a/api/data/articles/00004.json
+++ b/api/data/articles/00004.json
@@ -11,7 +11,9 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
-    "elocationId": "n/a",
+    "fpage": 26,
+    "lpage": 34,
+    "elocationId": "e135",
     "pdf": "http://web:8082/00004/ijm-00004.pdf",
     "subjects": [
         {

--- a/api/data/articles/00004.json
+++ b/api/data/articles/00004.json
@@ -13,7 +13,7 @@
     "issue": 1,
     "fpage": 26,
     "lpage": 34,
-    "elocationId": "e135",
+    "elocationId": "n/a",
     "pdf": "http://web:8082/00004/ijm-00004.pdf",
     "subjects": [
         {

--- a/api/data/articles/00005.json
+++ b/api/data/articles/00005.json
@@ -11,6 +11,8 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
+    "fpage": 35,
+    "lpage": 53,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00005/ijm-00005.pdf",
     "subjects": [

--- a/api/data/articles/00006.json
+++ b/api/data/articles/00006.json
@@ -11,6 +11,8 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
+    "fpage": 54,
+    "lpage": 56,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00006/ijm-00006.pdf",
     "subjects": [

--- a/api/data/articles/00007.json
+++ b/api/data/articles/00007.json
@@ -11,6 +11,8 @@
     "statusDate": "2007-12-31T00:00:00Z",
     "volume": 1,
     "issue": 1,
+    "fpage": 57,
+    "lpage": 58,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00007/ijm-00007.pdf",
     "subjects": [

--- a/api/data/articles/00008.json
+++ b/api/data/articles/00008.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-06-30T00:00:00Z",
     "volume": 2,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 15,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00008/ijm-00008.pdf",
     "subjects": [

--- a/api/data/articles/00009.json
+++ b/api/data/articles/00009.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-06-30T00:00:00Z",
     "volume": 2,
     "issue": 1,
+    "fpage": 16,
+    "lpage": 31,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00009/ijm-00009.pdf",
     "subjects": [

--- a/api/data/articles/00010.json
+++ b/api/data/articles/00010.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-06-30T00:00:00Z",
     "volume": 2,
     "issue": 1,
+    "fpage": 32,
+    "lpage": 48,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00010/ijm-00010.pdf",
     "subjects": [

--- a/api/data/articles/00011.json
+++ b/api/data/articles/00011.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-06-30T00:00:00Z",
     "volume": 2,
     "issue": 1,
+    "fpage": 49,
+    "lpage": 65,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00011/ijm-00011.pdf",
     "subjects": [

--- a/api/data/articles/00012.json
+++ b/api/data/articles/00012.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-06-30T00:00:00Z",
     "volume": 2,
     "issue": 1,
+    "fpage": 66,
+    "lpage": 67,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00012/ijm-00012.pdf",
     "subjects": [

--- a/api/data/articles/00013.json
+++ b/api/data/articles/00013.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 14,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00013/ijm-00013.pdf",
     "subjects": [

--- a/api/data/articles/00014.json
+++ b/api/data/articles/00014.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 15,
+    "lpage": 26,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00014/ijm-00014.pdf",
     "subjects": [

--- a/api/data/articles/00015.json
+++ b/api/data/articles/00015.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 27,
+    "lpage": 42,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00015/ijm-00015.pdf",
     "subjects": [

--- a/api/data/articles/00016.json
+++ b/api/data/articles/00016.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 43,
+    "lpage": 54,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00016/ijm-00016.pdf",
     "subjects": [

--- a/api/data/articles/00017.json
+++ b/api/data/articles/00017.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 55,
+    "lpage": 57,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00017/ijm-00017.pdf",
     "subjects": [

--- a/api/data/articles/00018.json
+++ b/api/data/articles/00018.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 58,
+    "lpage": 63,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00018/ijm-00018.pdf",
     "subjects": [

--- a/api/data/articles/00019.json
+++ b/api/data/articles/00019.json
@@ -11,6 +11,8 @@
     "statusDate": "2009-12-31T00:00:00Z",
     "volume": 2,
     "issue": 2,
+    "fpage": 64,
+    "lpage": 65,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00019/ijm-00019.pdf",
     "subjects": [

--- a/api/data/articles/00020.json
+++ b/api/data/articles/00020.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 7,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00020/ijm-00020.pdf",
     "subjects": [

--- a/api/data/articles/00021.json
+++ b/api/data/articles/00021.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 8,
+    "lpage": 23,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00021/ijm-00021.pdf",
     "subjects": [

--- a/api/data/articles/00022.json
+++ b/api/data/articles/00022.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 24,
+    "lpage": 34,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00022/ijm-00022.pdf",
     "subjects": [

--- a/api/data/articles/00023.json
+++ b/api/data/articles/00023.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 35,
+    "lpage": 42,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00023/ijm-00023.pdf",
     "subjects": [

--- a/api/data/articles/00024.json
+++ b/api/data/articles/00024.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 43,
+    "lpage": 59,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00024/ijm-00024.pdf",
     "subjects": [

--- a/api/data/articles/00025.json
+++ b/api/data/articles/00025.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 60,
+    "lpage": 71,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00025/ijm-00025.pdf",
     "subjects": [

--- a/api/data/articles/00026.json
+++ b/api/data/articles/00026.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 72,
+    "lpage": 91,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00026/ijm-00026.pdf",
     "subjects": [

--- a/api/data/articles/00027.json
+++ b/api/data/articles/00027.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 92,
+    "lpage": 103,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00027/ijm-00027.pdf",
     "subjects": [

--- a/api/data/articles/00028.json
+++ b/api/data/articles/00028.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 104,
+    "lpage": 108,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00028/ijm-00028.pdf",
     "subjects": [

--- a/api/data/articles/00029.json
+++ b/api/data/articles/00029.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 109,
+    "lpage": 113,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00029/ijm-00029.pdf",
     "subjects": [

--- a/api/data/articles/00030.json
+++ b/api/data/articles/00030.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 114,
+    "lpage": 117,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00030/ijm-00030.pdf",
     "subjects": [

--- a/api/data/articles/00031.json
+++ b/api/data/articles/00031.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 118,
+    "lpage": 122,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00031/ijm-00031.pdf",
     "subjects": [

--- a/api/data/articles/00032.json
+++ b/api/data/articles/00032.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 123,
+    "lpage": 126,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00032/ijm-00032.pdf",
     "subjects": [

--- a/api/data/articles/00033.json
+++ b/api/data/articles/00033.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-06-30T00:00:00Z",
     "volume": 3,
     "issue": 1,
+    "fpage": 127,
+    "lpage": 129,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00033/ijm-00033.pdf",
     "subjects": [

--- a/api/data/articles/00034.json
+++ b/api/data/articles/00034.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-12-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00034/ijm-00034.pdf",
     "abstract": {

--- a/api/data/articles/00035.json
+++ b/api/data/articles/00035.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-12-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 3,
+    "lpage": 22,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00035/ijm-00035.pdf",
     "subjects": [

--- a/api/data/articles/00036.json
+++ b/api/data/articles/00036.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-12-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 23,
+    "lpage": 33,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00036/ijm-00036.pdf",
     "subjects": [

--- a/api/data/articles/00037.json
+++ b/api/data/articles/00037.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-08-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 34,
+    "lpage": 45,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00037/ijm-00037.pdf",
     "subjects": [

--- a/api/data/articles/00038.json
+++ b/api/data/articles/00038.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-12-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 46,
+    "lpage": 64,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00038/ijm-00038.pdf",
     "subjects": [

--- a/api/data/articles/00039.json
+++ b/api/data/articles/00039.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-12-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 65,
+    "lpage": 79,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00039/ijm-00039.pdf",
     "subjects": [

--- a/api/data/articles/00040.json
+++ b/api/data/articles/00040.json
@@ -11,6 +11,8 @@
     "statusDate": "2010-12-31T00:00:00Z",
     "volume": 3,
     "issue": 2,
+    "fpage": 80,
+    "lpage": 89,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00040/ijm-00040.pdf",
     "subjects": [

--- a/api/data/articles/00041.json
+++ b/api/data/articles/00041.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 1,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00041/ijm-00041.pdf",
     "copyright": {

--- a/api/data/articles/00042.json
+++ b/api/data/articles/00042.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 2,
+    "lpage": 20,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00042/ijm-00042.pdf",
     "subjects": [

--- a/api/data/articles/00043.json
+++ b/api/data/articles/00043.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 21,
+    "lpage": 34,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00043/ijm-00043.pdf",
     "subjects": [

--- a/api/data/articles/00044.json
+++ b/api/data/articles/00044.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 35,
+    "lpage": 53,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00044/ijm-00044.pdf",
     "subjects": [

--- a/api/data/articles/00045.json
+++ b/api/data/articles/00045.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 54,
+    "lpage": 71,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00045/ijm-00045.pdf",
     "subjects": [

--- a/api/data/articles/00046.json
+++ b/api/data/articles/00046.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 72,
+    "lpage": 99,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00046/ijm-00046.pdf",
     "subjects": [

--- a/api/data/articles/00047.json
+++ b/api/data/articles/00047.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-04-30T00:00:00Z",
     "volume": 4,
     "issue": 1,
+    "fpage": 100,
+    "lpage": 105,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00047/ijm-00047.pdf",
     "subjects": [

--- a/api/data/articles/00048.json
+++ b/api/data/articles/00048.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 1,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00048/ijm-00048.pdf",
     "abstract": {

--- a/api/data/articles/00049.json
+++ b/api/data/articles/00049.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 3,
+    "lpage": 13,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00049/ijm-00049.pdf",
     "subjects": [

--- a/api/data/articles/00050.json
+++ b/api/data/articles/00050.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 14,
+    "lpage": 26,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00050/ijm-00050.pdf",
     "subjects": [

--- a/api/data/articles/00051.json
+++ b/api/data/articles/00051.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 27,
+    "lpage": 40,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00051/ijm-00051.pdf",
     "subjects": [

--- a/api/data/articles/00052.json
+++ b/api/data/articles/00052.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 41,
+    "lpage": 56,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00052/ijm-00052.pdf",
     "subjects": [

--- a/api/data/articles/00053.json
+++ b/api/data/articles/00053.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 57,
+    "lpage": 72,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00053/ijm-00053.pdf",
     "subjects": [

--- a/api/data/articles/00054.json
+++ b/api/data/articles/00054.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-08-31T00:00:00Z",
     "volume": 4,
     "issue": 2,
+    "fpage": 73,
+    "lpage": 85,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00054/ijm-00054.pdf",
     "subjects": [

--- a/api/data/articles/00055.json
+++ b/api/data/articles/00055.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00055/ijm-00055.pdf",
     "abstract": {

--- a/api/data/articles/00056.json
+++ b/api/data/articles/00056.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 3,
+    "lpage": 16,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00056/ijm-00056.pdf",
     "subjects": [

--- a/api/data/articles/00057.json
+++ b/api/data/articles/00057.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 17,
+    "lpage": 31,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00057/ijm-00057.pdf",
     "subjects": [

--- a/api/data/articles/00058.json
+++ b/api/data/articles/00058.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 32,
+    "lpage": 36,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00058/ijm-00058.pdf",
     "subjects": [

--- a/api/data/articles/00059.json
+++ b/api/data/articles/00059.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 37,
+    "lpage": 47,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00059/ijm-00059.pdf",
     "subjects": [

--- a/api/data/articles/00060.json
+++ b/api/data/articles/00060.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 48,
+    "lpage": 56,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00060/ijm-00060.pdf",
     "subjects": [

--- a/api/data/articles/00061.json
+++ b/api/data/articles/00061.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 57,
+    "lpage": 70,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00061/ijm-00061.pdf",
     "subjects": [

--- a/api/data/articles/00062.json
+++ b/api/data/articles/00062.json
@@ -11,6 +11,8 @@
     "statusDate": "2011-12-31T00:00:00Z",
     "volume": 4,
     "issue": 3,
+    "fpage": 71,
+    "lpage": 80,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00062/ijm-00062.pdf",
     "subjects": [

--- a/api/data/articles/00063.json
+++ b/api/data/articles/00063.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-06-30T00:00:00Z",
     "volume": 5,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 1,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00063/ijm-00063.pdf",
     "copyright": {

--- a/api/data/articles/00064.json
+++ b/api/data/articles/00064.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-06-30T00:00:00Z",
     "volume": 5,
     "issue": 1,
+    "fpage": 2,
+    "lpage": 20,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00064/ijm-00064.pdf",
     "subjects": [

--- a/api/data/articles/00065.json
+++ b/api/data/articles/00065.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-06-30T00:00:00Z",
     "volume": 5,
     "issue": 1,
+    "fpage": 21,
+    "lpage": 30,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00065/ijm-00065.pdf",
     "subjects": [

--- a/api/data/articles/00066.json
+++ b/api/data/articles/00066.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-06-30T00:00:00Z",
     "volume": 5,
     "issue": 1,
+    "fpage": 31,
+    "lpage": 51,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00066/ijm-00066.pdf",
     "subjects": [

--- a/api/data/articles/00067.json
+++ b/api/data/articles/00067.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-06-30T00:00:00Z",
     "volume": 5,
     "issue": 1,
+    "fpage": 52,
+    "lpage": 76,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00067/ijm-00067.pdf",
     "subjects": [

--- a/api/data/articles/00068.json
+++ b/api/data/articles/00068.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-12-31T00:00:00Z",
     "volume": 5,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 1,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00068/ijm-00068.pdf",
     "copyright": {

--- a/api/data/articles/00069.json
+++ b/api/data/articles/00069.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-12-31T00:00:00Z",
     "volume": 5,
     "issue": 2,
+    "fpage": 2,
+    "lpage": 21,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00069/ijm-00069.pdf",
     "subjects": [

--- a/api/data/articles/00070.json
+++ b/api/data/articles/00070.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-12-31T00:00:00Z",
     "volume": 5,
     "issue": 2,
+    "fpage": 22,
+    "lpage": 39,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00070/ijm-00070.pdf",
     "subjects": [

--- a/api/data/articles/00071.json
+++ b/api/data/articles/00071.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-12-31T00:00:00Z",
     "volume": 5,
     "issue": 2,
+    "fpage": 40,
+    "lpage": 58,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00071/ijm-00071.pdf",
     "subjects": [

--- a/api/data/articles/00072.json
+++ b/api/data/articles/00072.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-12-31T00:00:00Z",
     "volume": 5,
     "issue": 2,
+    "fpage": 59,
+    "lpage": 65,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00072/ijm-00072.pdf",
     "subjects": [

--- a/api/data/articles/00073.json
+++ b/api/data/articles/00073.json
@@ -11,6 +11,8 @@
     "statusDate": "2012-12-31T00:00:00Z",
     "volume": 5,
     "issue": 2,
+    "fpage": 66,
+    "lpage": 73,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00073/ijm-00073.pdf",
     "subjects": [

--- a/api/data/articles/00074.json
+++ b/api/data/articles/00074.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 3,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00074/ijm-00074.pdf",
     "copyright": {

--- a/api/data/articles/00075.json
+++ b/api/data/articles/00075.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 4,
+    "lpage": 26,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00075/ijm-00075.pdf",
     "subjects": [

--- a/api/data/articles/00076.json
+++ b/api/data/articles/00076.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 27,
+    "lpage": 62,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00076/ijm-00076.pdf",
     "subjects": [

--- a/api/data/articles/00077.json
+++ b/api/data/articles/00077.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 63,
+    "lpage": 85,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00077/ijm-00077.pdf",
     "subjects": [

--- a/api/data/articles/00078.json
+++ b/api/data/articles/00078.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 86,
+    "lpage": 121,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00078/ijm-00078.pdf",
     "subjects": [

--- a/api/data/articles/00079.json
+++ b/api/data/articles/00079.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 122,
+    "lpage": 156,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00079/ijm-00079.pdf",
     "subjects": [

--- a/api/data/articles/00080.json
+++ b/api/data/articles/00080.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-04-30T00:00:00Z",
     "volume": 6,
     "issue": 1,
+    "fpage": 157,
+    "lpage": 176,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00080/ijm-00080.pdf",
     "subjects": [

--- a/api/data/articles/00081.json
+++ b/api/data/articles/00081.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-08-31T00:00:00Z",
     "volume": 6,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00081/ijm-00081.pdf",
     "copyright": {

--- a/api/data/articles/00082.json
+++ b/api/data/articles/00082.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-08-31T00:00:00Z",
     "volume": 6,
     "issue": 2,
+    "fpage": 3,
+    "lpage": 55,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00082/ijm-00082.pdf",
     "subjects": [

--- a/api/data/articles/00083.json
+++ b/api/data/articles/00083.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-08-31T00:00:00Z",
     "volume": 6,
     "issue": 2,
+    "fpage": 56,
+    "lpage": 75,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00083/ijm-00083.pdf",
     "subjects": [

--- a/api/data/articles/00084.json
+++ b/api/data/articles/00084.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-08-31T00:00:00Z",
     "volume": 6,
     "issue": 2,
+    "fpage": 76,
+    "lpage": 122,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00084/ijm-00084.pdf",
     "subjects": [

--- a/api/data/articles/00085.json
+++ b/api/data/articles/00085.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-12-31T00:00:00Z",
     "volume": 6,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00085/ijm-00085.pdf",
     "copyright": {

--- a/api/data/articles/00086.json
+++ b/api/data/articles/00086.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-12-31T00:00:00Z",
     "volume": 6,
     "issue": 3,
+    "fpage": 2,
+    "lpage": 20,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00086/ijm-00086.pdf",
     "subjects": [

--- a/api/data/articles/00087.json
+++ b/api/data/articles/00087.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-12-31T00:00:00Z",
     "volume": 6,
     "issue": 3,
+    "fpage": 25,
+    "lpage": 49,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00087/ijm-00087.pdf",
     "subjects": [

--- a/api/data/articles/00088.json
+++ b/api/data/articles/00088.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-12-31T00:00:00Z",
     "volume": 6,
     "issue": 3,
+    "fpage": 50,
+    "lpage": 77,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00088/ijm-00088.pdf",
     "subjects": [

--- a/api/data/articles/00089.json
+++ b/api/data/articles/00089.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-12-31T00:00:00Z",
     "volume": 6,
     "issue": 3,
+    "fpage": 78,
+    "lpage": 117,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00089/ijm-00089.pdf",
     "subjects": [

--- a/api/data/articles/00090.json
+++ b/api/data/articles/00090.json
@@ -11,6 +11,8 @@
     "statusDate": "2013-12-31T00:00:00Z",
     "volume": 6,
     "issue": 3,
+    "fpage": 118,
+    "lpage": 121,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00090/ijm-00090.pdf",
     "subjects": [

--- a/api/data/articles/00091.json
+++ b/api/data/articles/00091.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 3,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00091/ijm-00091.pdf",
     "copyright": {

--- a/api/data/articles/00092.json
+++ b/api/data/articles/00092.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
+    "fpage": 4,
+    "lpage": 25,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00092/ijm-00092.pdf",
     "subjects": [
@@ -2187,7 +2189,8 @@
             "details": "102\u2013120, Old, Single and Poor: Using Microsimulation and Microdata to Analyse Poverty and the Impact of Policy Change among Older Australians. Economic Papers: A journal of applied economics and policy, 28, 2, 10.1111/j.1759-3441.2009.00022.x%20",
             "id": "bib40",
             "title": "Old, Single and Poor: Using Microsimulation and Microdata to Analyse Poverty and the Impact of Policy Change among Older Australians. Economic Papers: A journal of applied economics and policy",
-            "type": "unknown"
+            "type": "unknown",
+            "uri": "https://doi.org/10.1111/j.1759-3441.2009.00022.x%20"
         },
         {
             "articleTitle": "Small area estimation using a reweighting algorithm",

--- a/api/data/articles/00093.json
+++ b/api/data/articles/00093.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
+    "fpage": 26,
+    "lpage": 75,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00093/ijm-00093.pdf",
     "subjects": [

--- a/api/data/articles/00094.json
+++ b/api/data/articles/00094.json
@@ -13,7 +13,7 @@
     "issue": 1,
     "fpage": 76,
     "lpage": 99,
-    "elocationId": "1351.0.55.006",
+    "elocationId": "n/a",
     "pdf": "http://web:8082/00094/ijm-00094.pdf",
     "subjects": [
         {

--- a/api/data/articles/00094.json
+++ b/api/data/articles/00094.json
@@ -11,7 +11,9 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
-    "elocationId": "n/a",
+    "fpage": 76,
+    "lpage": 99,
+    "elocationId": "1351.0.55.006",
     "pdf": "http://web:8082/00094/ijm-00094.pdf",
     "subjects": [
         {

--- a/api/data/articles/00095.json
+++ b/api/data/articles/00095.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
+    "fpage": 100,
+    "lpage": 126,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00095/ijm-00095.pdf",
     "subjects": [

--- a/api/data/articles/00096.json
+++ b/api/data/articles/00096.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
+    "fpage": 127,
+    "lpage": 157,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00096/ijm-00096.pdf",
     "subjects": [

--- a/api/data/articles/00097.json
+++ b/api/data/articles/00097.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-04-30T00:00:00Z",
     "volume": 7,
     "issue": 1,
+    "fpage": 158,
+    "lpage": 193,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00097/ijm-00097.pdf",
     "subjects": [

--- a/api/data/articles/00098.json
+++ b/api/data/articles/00098.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-08-31T00:00:00Z",
     "volume": 7,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00098/ijm-00098.pdf",
     "copyright": {

--- a/api/data/articles/00099.json
+++ b/api/data/articles/00099.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-08-31T00:00:00Z",
     "volume": 7,
     "issue": 2,
+    "fpage": 3,
+    "lpage": 39,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00099/ijm-00099.pdf",
     "subjects": [

--- a/api/data/articles/00100.json
+++ b/api/data/articles/00100.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-08-31T00:00:00Z",
     "volume": 7,
     "issue": 2,
+    "fpage": 40,
+    "lpage": 93,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00100/ijm-00100.pdf",
     "subjects": [

--- a/api/data/articles/00101.json
+++ b/api/data/articles/00101.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-08-31T00:00:00Z",
     "volume": 7,
     "issue": 2,
+    "fpage": 94,
+    "lpage": 118,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00101/ijm-00101.pdf",
     "subjects": [

--- a/api/data/articles/00102.json
+++ b/api/data/articles/00102.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-08-31T00:00:00Z",
     "volume": 7,
     "issue": 2,
+    "fpage": 119,
+    "lpage": 146,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00102/ijm-00102.pdf",
     "subjects": [

--- a/api/data/articles/00103.json
+++ b/api/data/articles/00103.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-08-31T00:00:00Z",
     "volume": 7,
     "issue": 2,
+    "fpage": 147,
+    "lpage": 149,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00103/ijm-00103.pdf",
     "subjects": [

--- a/api/data/articles/00104.json
+++ b/api/data/articles/00104.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-12-31T00:00:00Z",
     "volume": 7,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00104/ijm-00104.pdf",
     "copyright": {

--- a/api/data/articles/00105.json
+++ b/api/data/articles/00105.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-12-31T00:00:00Z",
     "volume": 7,
     "issue": 3,
+    "fpage": 3,
+    "lpage": 32,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00105/ijm-00105.pdf",
     "subjects": [

--- a/api/data/articles/00106.json
+++ b/api/data/articles/00106.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-12-31T00:00:00Z",
     "volume": 7,
     "issue": 3,
+    "fpage": 33,
+    "lpage": 52,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00106/ijm-00106.pdf",
     "subjects": [

--- a/api/data/articles/00107.json
+++ b/api/data/articles/00107.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-12-31T00:00:00Z",
     "volume": 7,
     "issue": 3,
+    "fpage": 53,
+    "lpage": 79,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00107/ijm-00107.pdf",
     "subjects": [

--- a/api/data/articles/00108.json
+++ b/api/data/articles/00108.json
@@ -11,6 +11,8 @@
     "statusDate": "2014-12-31T00:00:00Z",
     "volume": 7,
     "issue": 3,
+    "fpage": 80,
+    "lpage": 86,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00108/ijm-00108.pdf",
     "subjects": [

--- a/api/data/articles/00109.json
+++ b/api/data/articles/00109.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-04-30T00:00:00Z",
     "volume": 8,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00109/ijm-00109.pdf",
     "copyright": {

--- a/api/data/articles/00110.json
+++ b/api/data/articles/00110.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-04-30T00:00:00Z",
     "volume": 8,
     "issue": 1,
+    "fpage": 3,
+    "lpage": 32,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00110/ijm-00110.pdf",
     "subjects": [

--- a/api/data/articles/00111.json
+++ b/api/data/articles/00111.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-04-30T00:00:00Z",
     "volume": 8,
     "issue": 1,
+    "fpage": 33,
+    "lpage": 66,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00111/ijm-00111.pdf",
     "subjects": [

--- a/api/data/articles/00112.json
+++ b/api/data/articles/00112.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-04-30T00:00:00Z",
     "volume": 8,
     "issue": 1,
+    "fpage": 67,
+    "lpage": 96,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00112/ijm-00112.pdf",
     "subjects": [

--- a/api/data/articles/00113.json
+++ b/api/data/articles/00113.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-04-30T00:00:00Z",
     "volume": 8,
     "issue": 1,
+    "fpage": 97,
+    "lpage": 109,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00113/ijm-00113.pdf",
     "subjects": [

--- a/api/data/articles/00114.json
+++ b/api/data/articles/00114.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-08-31T00:00:00Z",
     "volume": 8,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 3,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00114/ijm-00114.pdf",
     "copyright": {

--- a/api/data/articles/00115.json
+++ b/api/data/articles/00115.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-08-31T00:00:00Z",
     "volume": 8,
     "issue": 2,
+    "fpage": 4,
+    "lpage": 27,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00115/ijm-00115.pdf",
     "subjects": [

--- a/api/data/articles/00116.json
+++ b/api/data/articles/00116.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-08-31T00:00:00Z",
     "volume": 8,
     "issue": 2,
+    "fpage": 28,
+    "lpage": 60,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00116/ijm-00116.pdf",
     "subjects": [

--- a/api/data/articles/00117.json
+++ b/api/data/articles/00117.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-08-31T00:00:00Z",
     "volume": 8,
     "issue": 2,
+    "fpage": 83,
+    "lpage": 127,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00117/ijm-00117.pdf",
     "subjects": [

--- a/api/data/articles/00118.json
+++ b/api/data/articles/00118.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-08-31T00:00:00Z",
     "volume": 8,
     "issue": 2,
+    "fpage": 152,
+    "lpage": 175,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00118/ijm-00118.pdf",
     "subjects": [

--- a/api/data/articles/00119.json
+++ b/api/data/articles/00119.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-12-31T00:00:00Z",
     "volume": 8,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 5,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00119/ijm-00119.pdf",
     "copyright": {

--- a/api/data/articles/00120.json
+++ b/api/data/articles/00120.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-12-31T00:00:00Z",
     "volume": 8,
     "issue": 3,
+    "fpage": 6,
+    "lpage": 40,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00120/ijm-00120.pdf",
     "subjects": [

--- a/api/data/articles/00121.json
+++ b/api/data/articles/00121.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-12-31T00:00:00Z",
     "volume": 8,
     "issue": 3,
+    "fpage": 41,
+    "lpage": 74,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00121/ijm-00121.pdf",
     "subjects": [

--- a/api/data/articles/00122.json
+++ b/api/data/articles/00122.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-12-31T00:00:00Z",
     "volume": 8,
     "issue": 3,
+    "fpage": 75,
+    "lpage": 98,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00122/ijm-00122.pdf",
     "subjects": [

--- a/api/data/articles/00123.json
+++ b/api/data/articles/00123.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-12-31T00:00:00Z",
     "volume": 8,
     "issue": 3,
+    "fpage": 99,
+    "lpage": 136,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00123/ijm-00123.pdf",
     "subjects": [

--- a/api/data/articles/00124.json
+++ b/api/data/articles/00124.json
@@ -11,6 +11,8 @@
     "statusDate": "2015-12-31T00:00:00Z",
     "volume": 8,
     "issue": 3,
+    "fpage": 148,
+    "lpage": 151,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00124/ijm-00124.pdf",
     "subjects": [

--- a/api/data/articles/00125.json
+++ b/api/data/articles/00125.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 4,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00125/ijm-00125.pdf",
     "copyright": {

--- a/api/data/articles/00126.json
+++ b/api/data/articles/00126.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 5,
+    "lpage": 23,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00126/ijm-00126.pdf",
     "subjects": [

--- a/api/data/articles/00127.json
+++ b/api/data/articles/00127.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 24,
+    "lpage": 54,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00127/ijm-00127.pdf",
     "subjects": [

--- a/api/data/articles/00128.json
+++ b/api/data/articles/00128.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 55,
+    "lpage": 85,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00128/ijm-00128.pdf",
     "subjects": [

--- a/api/data/articles/00129.json
+++ b/api/data/articles/00129.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 86,
+    "lpage": 108,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00129/ijm-00129.pdf",
     "subjects": [

--- a/api/data/articles/00130.json
+++ b/api/data/articles/00130.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 109,
+    "lpage": 133,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00130/ijm-00130.pdf",
     "subjects": [

--- a/api/data/articles/00131.json
+++ b/api/data/articles/00131.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 134,
+    "lpage": 166,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00131/ijm-00131.pdf",
     "subjects": [

--- a/api/data/articles/00132.json
+++ b/api/data/articles/00132.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-04-30T00:00:00Z",
     "volume": 9,
     "issue": 1,
+    "fpage": 167,
+    "lpage": 174,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00132/ijm-00132.pdf",
     "subjects": [

--- a/api/data/articles/00133.json
+++ b/api/data/articles/00133.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 4,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00133/ijm-00133.pdf",
     "copyright": {

--- a/api/data/articles/00134.json
+++ b/api/data/articles/00134.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": 5,
+    "lpage": 40,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00134/ijm-00134.pdf",
     "subjects": [

--- a/api/data/articles/00135.json
+++ b/api/data/articles/00135.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": 41,
+    "lpage": 76,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00135/ijm-00135.pdf",
     "subjects": [

--- a/api/data/articles/00136.json
+++ b/api/data/articles/00136.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": 77,
+    "lpage": 105,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00136/ijm-00136.pdf",
     "subjects": [

--- a/api/data/articles/00137.json
+++ b/api/data/articles/00137.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": 106,
+    "lpage": 122,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00137/ijm-00137.pdf",
     "subjects": [

--- a/api/data/articles/00138.json
+++ b/api/data/articles/00138.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": "x",
+    "lpage": "y",
     "elocationId": "n/a",
     "pdf": "http://web:8082/00138/ijm-00138.pdf",
     "subjects": [

--- a/api/data/articles/00139.json
+++ b/api/data/articles/00139.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-08-31T00:00:00Z",
     "volume": 9,
     "issue": 2,
+    "fpage": 144,
+    "lpage": 191,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00139/ijm-00139.pdf",
     "subjects": [

--- a/api/data/articles/00140.json
+++ b/api/data/articles/00140.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 4,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00140/ijm-00140.pdf",
     "copyright": {

--- a/api/data/articles/00141.json
+++ b/api/data/articles/00141.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 5,
+    "lpage": 34,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00141/ijm-00141.pdf",
     "subjects": [

--- a/api/data/articles/00142.json
+++ b/api/data/articles/00142.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 35,
+    "lpage": 65,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00142/ijm-00142.pdf",
     "subjects": [

--- a/api/data/articles/00143.json
+++ b/api/data/articles/00143.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 66,
+    "lpage": 88,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00143/ijm-00143.pdf",
     "subjects": [

--- a/api/data/articles/00144.json
+++ b/api/data/articles/00144.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 89,
+    "lpage": 102,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00144/ijm-00144.pdf",
     "subjects": [

--- a/api/data/articles/00145.json
+++ b/api/data/articles/00145.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 103,
+    "lpage": 139,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00145/ijm-00145.pdf",
     "subjects": [

--- a/api/data/articles/00146.json
+++ b/api/data/articles/00146.json
@@ -11,6 +11,8 @@
     "statusDate": "2016-12-31T00:00:00Z",
     "volume": 9,
     "issue": 3,
+    "fpage": 140,
+    "lpage": 176,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00146/ijm-00146.pdf",
     "subjects": [

--- a/api/data/articles/00147.json
+++ b/api/data/articles/00147.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 4,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00147/ijm-00147.pdf",
     "copyright": {

--- a/api/data/articles/00148.json
+++ b/api/data/articles/00148.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 5,
+    "lpage": 38,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00148/ijm-00148.pdf",
     "subjects": [

--- a/api/data/articles/00149.json
+++ b/api/data/articles/00149.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 39,
+    "lpage": 72,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00149/ijm-00149.pdf",
     "subjects": [

--- a/api/data/articles/00150.json
+++ b/api/data/articles/00150.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 73,
+    "lpage": 105,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00150/ijm-00150.pdf",
     "subjects": [

--- a/api/data/articles/00151.json
+++ b/api/data/articles/00151.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 106,
+    "lpage": 134,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00151/ijm-00151.pdf",
     "subjects": [

--- a/api/data/articles/00152.json
+++ b/api/data/articles/00152.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 135,
+    "lpage": 166,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00152/ijm-00152.pdf",
     "subjects": [

--- a/api/data/articles/00153.json
+++ b/api/data/articles/00153.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 167,
+    "lpage": 200,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00153/ijm-00153.pdf",
     "subjects": [

--- a/api/data/articles/00154.json
+++ b/api/data/articles/00154.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-04-30T00:00:00Z",
     "volume": 10,
     "issue": 1,
+    "fpage": 201,
+    "lpage": 203,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00154/ijm-00154.pdf",
     "subjects": [

--- a/api/data/articles/00155.json
+++ b/api/data/articles/00155.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 2,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00155/ijm-00155.pdf",
     "copyright": {

--- a/api/data/articles/00156.json
+++ b/api/data/articles/00156.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 3,
+    "lpage": 85,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00156/ijm-00156.pdf",
     "subjects": [

--- a/api/data/articles/00157.json
+++ b/api/data/articles/00157.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 86,
+    "lpage": 102,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00157/ijm-00157.pdf",
     "subjects": [

--- a/api/data/articles/00158.json
+++ b/api/data/articles/00158.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 103,
+    "lpage": 117,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00158/ijm-00158.pdf",
     "subjects": [

--- a/api/data/articles/00159.json
+++ b/api/data/articles/00159.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 118,
+    "lpage": 143,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00159/ijm-00159.pdf",
     "subjects": [

--- a/api/data/articles/00160.json
+++ b/api/data/articles/00160.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 144,
+    "lpage": 176,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00160/ijm-00160.pdf",
     "subjects": [

--- a/api/data/articles/00161.json
+++ b/api/data/articles/00161.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 177,
+    "lpage": 207,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00161/ijm-00161.pdf",
     "subjects": [

--- a/api/data/articles/00162.json
+++ b/api/data/articles/00162.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-08-31T00:00:00Z",
     "volume": 10,
     "issue": 2,
+    "fpage": 208,
+    "lpage": 209,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00162/ijm-00162.pdf",
     "subjects": [

--- a/api/data/articles/00163.json
+++ b/api/data/articles/00163.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 4,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00163/ijm-00163.pdf",
     "copyright": {

--- a/api/data/articles/00164.json
+++ b/api/data/articles/00164.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 5,
+    "lpage": 26,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00164/ijm-00164.pdf",
     "subjects": [

--- a/api/data/articles/00165.json
+++ b/api/data/articles/00165.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 27,
+    "lpage": 58,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00165/ijm-00165.pdf",
     "subjects": [

--- a/api/data/articles/00166.json
+++ b/api/data/articles/00166.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 75,
+    "lpage": 91,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00166/ijm-00166.pdf",
     "subjects": [

--- a/api/data/articles/00167.json
+++ b/api/data/articles/00167.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 92,
+    "lpage": 133,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00167/ijm-00167.pdf",
     "subjects": [

--- a/api/data/articles/00168.json
+++ b/api/data/articles/00168.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 134,
+    "lpage": 164,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00168/ijm-00168.pdf",
     "subjects": [

--- a/api/data/articles/00169.json
+++ b/api/data/articles/00169.json
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 184,
+    "lpage": 201,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00169/ijm-00169.pdf",
     "subjects": [

--- a/api/data/articles/00170.json
+++ b/api/data/articles/00170.json
@@ -2,7 +2,7 @@
     "status": "vor",
     "id": "00170",
     "version": 1,
-    "type": "short-report",
+    "type": "scientific-correspondence",
     "doi": "10.34196/ijm.00170",
     "authorLine": "Dan Tang",
     "title": "The code is the model, <i>Sometimes</i>: A response to \u201cThe code is the model\u201d, by Luzius Meisser",
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 202,
+    "lpage": 203,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00170/ijm-00170.pdf",
     "subjects": [

--- a/api/data/articles/00171.json
+++ b/api/data/articles/00171.json
@@ -2,7 +2,7 @@
     "status": "vor",
     "id": "00171",
     "version": 1,
-    "type": "short-report",
+    "type": "scientific-correspondence",
     "doi": "10.34196/ijm.00171",
     "authorLine": "Richiardi G. Matteo",
     "title": "The code <i>and</i> the model: A response to \u201cThe code is the model\u201d, by Luzius Meisser",
@@ -11,6 +11,8 @@
     "statusDate": "2017-12-31T00:00:00Z",
     "volume": 10,
     "issue": 3,
+    "fpage": 204,
+    "lpage": 208,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00171/ijm-00171.pdf",
     "subjects": [

--- a/api/data/articles/00172.json
+++ b/api/data/articles/00172.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 3,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00172/ijm-00172.pdf",
     "copyright": {

--- a/api/data/articles/00173.json
+++ b/api/data/articles/00173.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 4,
+    "lpage": 60,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00173/ijm-00173.pdf",
     "subjects": [

--- a/api/data/articles/00174.json
+++ b/api/data/articles/00174.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 61,
+    "lpage": 96,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00174/ijm-00174.pdf",
     "subjects": [

--- a/api/data/articles/00175.json
+++ b/api/data/articles/00175.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 97,
+    "lpage": 142,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00175/ijm-00175.pdf",
     "subjects": [

--- a/api/data/articles/00176.json
+++ b/api/data/articles/00176.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 143,
+    "lpage": 161,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00176/ijm-00176.pdf",
     "subjects": [

--- a/api/data/articles/00177.json
+++ b/api/data/articles/00177.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 162,
+    "lpage": 197,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00177/ijm-00177.pdf",
     "subjects": [

--- a/api/data/articles/00178.json
+++ b/api/data/articles/00178.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-04-30T00:00:00Z",
     "volume": 11,
     "issue": 1,
+    "fpage": 198,
+    "lpage": 223,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00178/ijm-00178.pdf",
     "subjects": [

--- a/api/data/articles/00179.json
+++ b/api/data/articles/00179.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 1,
+    "lpage": 4,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00179/ijm-00179.pdf",
     "copyright": {

--- a/api/data/articles/00180.json
+++ b/api/data/articles/00180.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 5,
+    "lpage": 51,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00180/ijm-00180.pdf",
     "subjects": [

--- a/api/data/articles/00181.json
+++ b/api/data/articles/00181.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 84,
+    "lpage": 108,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00181/ijm-00181.pdf",
     "subjects": [

--- a/api/data/articles/00182.json
+++ b/api/data/articles/00182.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 122,
+    "lpage": 145,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00182/ijm-00182.pdf",
     "subjects": [

--- a/api/data/articles/00183.json
+++ b/api/data/articles/00183.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 146,
+    "lpage": 168,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00183/ijm-00183.pdf",
     "subjects": [

--- a/api/data/articles/00184.json
+++ b/api/data/articles/00184.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 169,
+    "lpage": 190,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00184/ijm-00184.pdf",
     "subjects": [

--- a/api/data/articles/00185.json
+++ b/api/data/articles/00185.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-08-31T00:00:00Z",
     "volume": 11,
     "issue": 2,
+    "fpage": 191,
+    "lpage": 213,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00185/ijm-00185.pdf",
     "subjects": [

--- a/api/data/articles/00186.json
+++ b/api/data/articles/00186.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-12-31T00:00:00Z",
     "volume": 11,
     "issue": 3,
+    "fpage": 1,
+    "lpage": 1,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00186/ijm-00186.pdf",
     "copyright": {

--- a/api/data/articles/00187.json
+++ b/api/data/articles/00187.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-12-31T00:00:00Z",
     "volume": 11,
     "issue": 3,
+    "fpage": 2,
+    "lpage": 38,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00187/ijm-00187.pdf",
     "subjects": [

--- a/api/data/articles/00188.json
+++ b/api/data/articles/00188.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-12-31T00:00:00Z",
     "volume": 11,
     "issue": 3,
+    "fpage": 39,
+    "lpage": 58,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00188/ijm-00188.pdf",
     "abstract": {

--- a/api/data/articles/00189.json
+++ b/api/data/articles/00189.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-12-31T00:00:00Z",
     "volume": 11,
     "issue": 3,
+    "fpage": 78,
+    "lpage": 99,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00189/ijm-00189.pdf",
     "subjects": [

--- a/api/data/articles/00190.json
+++ b/api/data/articles/00190.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-12-31T00:00:00Z",
     "volume": 11,
     "issue": 3,
+    "fpage": 100,
+    "lpage": 121,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00190/ijm-00190.pdf",
     "subjects": [

--- a/api/data/articles/00191.json
+++ b/api/data/articles/00191.json
@@ -11,6 +11,8 @@
     "statusDate": "2018-12-31T00:00:00Z",
     "volume": 11,
     "issue": 3,
+    "fpage": 134,
+    "lpage": 168,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00191/ijm-00191.pdf",
     "subjects": [

--- a/api/data/articles/00192.json
+++ b/api/data/articles/00192.json
@@ -11,6 +11,8 @@
     "statusDate": "2019-04-30T00:00:00Z",
     "volume": 12,
     "issue": 1,
+    "fpage": 1,
+    "lpage": 12,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00192/ijm-00192.pdf",
     "subjects": [

--- a/api/data/articles/00193.json
+++ b/api/data/articles/00193.json
@@ -11,6 +11,8 @@
     "statusDate": "2019-04-30T00:00:00Z",
     "volume": 12,
     "issue": 1,
+    "fpage": 13,
+    "lpage": 51,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00193/ijm-00193.pdf",
     "subjects": [

--- a/api/data/articles/00194.json
+++ b/api/data/articles/00194.json
@@ -11,6 +11,8 @@
     "statusDate": "2019-04-30T00:00:00Z",
     "volume": 12,
     "issue": 1,
+    "fpage": 52,
+    "lpage": 82,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00194/ijm-00194.pdf",
     "subjects": [

--- a/api/data/articles/00195.json
+++ b/api/data/articles/00195.json
@@ -11,6 +11,8 @@
     "statusDate": "2019-04-30T00:00:00Z",
     "volume": 12,
     "issue": 1,
+    "fpage": 83,
+    "lpage": 104,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00195/ijm-00195.pdf",
     "subjects": [

--- a/api/data/articles/00196.json
+++ b/api/data/articles/00196.json
@@ -13,7 +13,7 @@
     "issue": 1,
     "fpage": 105,
     "lpage": 123,
-    "elocationId": "n/a",
+    "elocationId": "105-123",
     "pdf": "http://web:8082/00196/ijm-00196.pdf",
     "subjects": [
         {

--- a/api/data/articles/00196.json
+++ b/api/data/articles/00196.json
@@ -11,6 +11,8 @@
     "statusDate": "2019-04-30T00:00:00Z",
     "volume": 12,
     "issue": 1,
+    "fpage": 105,
+    "lpage": 123,
     "elocationId": "n/a",
     "pdf": "http://web:8082/00196/ijm-00196.pdf",
     "subjects": [


### PR DESCRIPTION
Existing articles to include the `fpage` and `lpage` values. This PR includes those only, except for a couple things to note:

- 00138 has `fpage` x and `lpage` y, which I assume will be changed in the XML eventually
- 00170 and 00171 had their display channel changed to `scientific-correspondence` as a result of generating again, I think this reflects some code changes that happened after those articles were originally generated
- 00092 has a citation where an extra DOI was included, which is hopefully acceptable

FYI to @FAtherden-eLife.

I'm not sure who intends to review or merge this PR?